### PR TITLE
Change luerl dep to hex (now that it's on hex)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -54,8 +54,7 @@ defmodule Lua.Mixfile do
      {:earmark,     ">= 0.0.0", only: :dev},
      {:ex_doc,      ">= 0.0.0", only: :dev},
      {:excoveralls, ">= 0.0.0", only: :test},
-     {:luerl, github: "bendiken/luerl", branch: "exlua",
-              compile: "make && cp src/luerl.app.src ebin/luerl.app"}]
+     {:luerl, "~> 0.3"}]
   end
 
   defp aliases do

--- a/mix.lock
+++ b/mix.lock
@@ -9,7 +9,7 @@
   "hackney": {:hex, :hackney, "1.6.1", "ddd22d42db2b50e6a155439c8811b8f6df61a4395de10509714ad2751c6da817", [:rebar3], [{:certifi, "0.4.0", [hex: :certifi, optional: false]}, {:idna, "1.2.0", [hex: :idna, optional: false]}, {:metrics, "1.0.1", [hex: :metrics, optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, optional: false]}, {:ssl_verify_fun, "1.1.0", [hex: :ssl_verify_fun, optional: false]}]},
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
   "jsx": {:hex, :jsx, "2.6.2", "213721e058da0587a4bce3cc8a00ff6684ced229c8f9223245c6ff2c88fbaa5a", [:mix, :rebar], []},
-  "luerl": {:git, "https://github.com/bendiken/luerl.git", "3e697635bf71d840cb08876d1ac1924ea13933bb", [branch: "exlua"]},
+  "luerl": {:hex, :luerl, "0.3.1", "5412807630aac1aaf59ffe5a1bc09259c447b4faeb1d3fe2d4ef41b87676cb04", [:rebar3], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []}}


### PR DESCRIPTION
Changes deps to depend on luerl version published through hex. Should make hex generally happier, and make exlua easier to use (no need to explicitly include luerl from project using exlua).